### PR TITLE
Adding error_stream class property because ghdl reports lint error in…

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,7 +10,7 @@
 
 """This module exports the Ghdl plugin class."""
 
-from SublimeLinter.lint import Linter
+from SublimeLinter.lint import Linter, util
 
 
 class Ghdl(Linter):
@@ -18,10 +18,12 @@ class Ghdl(Linter):
     """Provides an interface to ghdl."""
 
     syntax = 'vhdl'
-    cmd = 'ghdl -a @'
+    cmd = 'ghdl -a $file'
     version_re = r'GHDL (?P<version>\d+\.\d+)'
     version_requirement = '>= 0.31'
     tempfile_suffix = 'vhd'
+
+    error_stream = util.STREAM_STDERR
 
     # Here is a sample ghdl error output:
     # ----8<------------

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,6 @@ from SublimeLinter.lint import Linter, util
 
 
 class Ghdl(Linter):
-
     """Provides an interface to ghdl."""
 
     syntax = 'vhdl'


### PR DESCRIPTION
… stderr not stdout

ghdl version 0.31 for windows returns linting errors on stderr, not stdio. If error_stream is set to the default of util.STREAM_BOTH SublimeLinter parses the linting errors as runtime errors and fails to properly parse and display linting results.  Changing the error_stream to util.STREAM_STDERR allows SublimeLinter to parse and display the linting results properly.

Additionally, using @ to substitute for filename is not longer supported, so $file was inserted to update to the current standard.